### PR TITLE
Debug incorrect antenna gains when ANTENNA_MODE=1

### DIFF
--- a/Detector.cc
+++ b/Detector.cc
@@ -1004,10 +1004,10 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
 	}
 	else if (settings1->ANTENNA_MODE == 1) {
 	  // test read V-pol gain file!!
-	  ReadVgain("ARA_bicone6in_output.txt", settings1);
-	  ReadVgainTop("ARA_VPresult_topTrec.txt", settings1);
+	  ReadVgainSettings("ARA_bicone6in_output_updated2016.txt", settings1);
+	  ReadVgainTopSettings("ARA_VPresult_topTrec.txt", settings1);
 	  // test read H-pol gain file!!
-	  ReadHgain("ARA_dipoletest1_output.txt", settings1);
+	  ReadHgainSettings("ARA_dipoletest1_output_updated2016.txt", settings1);
 	}
 	else if (settings1->ANTENNA_MODE == 2){
 	  // test read V-pol gain file!!
@@ -1491,10 +1491,10 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
 	}
 	else if (settings1->ANTENNA_MODE == 1) {
 	  // test read V-pol gain file!!
-	  ReadVgain("ARA_bicone6in_output.txt", settings1);
-	  ReadVgainTop("ARA_VPresult_topTrec.txt", settings1);
+	  ReadVgainSettings("ARA_bicone6in_output_updated2016.txt", settings1);
+	  ReadVgainTopSettings("ARA_VPresult_topTrec.txt", settings1);
 	  // test read H-pol gain file!!
-	  ReadHgain("ARA_dipoletest1_output.txt", settings1);
+	  ReadHgainSettings("ARA_dipoletest1_output_updated2016.txt", settings1);
 	}
 	else if (settings1->ANTENNA_MODE == 2){
 	  // test read V-pol gain file!!
@@ -1778,10 +1778,10 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
 	    }
 	    else if (settings1->ANTENNA_MODE == 1) {
 	      // test read V-pol gain file!!
-	      ReadVgain("ARA_bicone6in_output.txt", settings1);
-	      ReadVgainTop("ARA_VPresult_topTrec.txt", settings1);
+	      ReadVgainSettings("ARA_bicone6in_output_updated2016.txt", settings1);
+	      ReadVgainTopSettings("ARA_VPresult_topTrec.txt", settings1);
 	      // test read H-pol gain file!!
-	      ReadHgain("ARA_dipoletest1_output.txt", settings1);
+	      ReadHgainSettings("ARA_dipoletest1_output_updated2016.txt", settings1);
 	    }
 	    else if (settings1->ANTENNA_MODE == 2) {
 	      // test read V-pol gain file!!
@@ -2081,10 +2081,10 @@ Detector::Detector(Settings *settings1, IceModel *icesurface, string setupfile) 
 	    }
 	    else if (settings1->ANTENNA_MODE == 1) {
 	      // test read V-pol gain file!!
-	      ReadVgain("ARA_bicone6in_output.txt", settings1);
-	      ReadVgainTop("ARA_VPresult_topTrec.txt", settings1);
+	      ReadVgainSettings("ARA_bicone6in_output_updated2016.txt", settings1);
+	      ReadVgainTopSettings("ARA_VPresult_topTrec.txt", settings1);
 	      // test read H-pol gain file!!
-	      ReadHgain("ARA_dipoletest1_output.txt", settings1);
+	      ReadHgainSettings("ARA_dipoletest1_output_updated2016.txt", settings1);
 	    }
 	    else if (settings1->ANTENNA_MODE == 2){
 	      // test read V-pol gain file!!
@@ -2288,7 +2288,7 @@ inline void Detector::ReadVgain(string filename) {
 
 }// end ReadVgain
 
-inline void Detector::ReadVgain(string filename, Settings *settings1) {
+inline void Detector::ReadVgainSettings(string filename, Settings *settings1) {
     ifstream NecOut( filename.c_str() );
     const int N = freq_step;
     double Transm[N];
@@ -2303,13 +2303,13 @@ inline void Detector::ReadVgain(string filename, Settings *settings1) {
                     Freq[i] = atof( line.substr(6, line.find_first_of("M")).c_str() );
                     //                    cout<<"freq["<<i<<"] = "<<Freq[i]<<" MHz"<<endl;
                     getline (NecOut, line); //read SWR
-		    Transm[i] = atof(line.substr(5,11).c_str());
+           		     Transm[i] = atof(line.substr(5,11).c_str()); //What says "SWR" in "ARA_bicone6in_output_updated2016.txt" is actually trasnmission coefficient - MYL 01/23/20
                     getline (NecOut, line); //read names
 
                     for (int j=0; j<ang_step; j++) {
                         getline (NecOut, line); //read data line
                         //Vgain[i][j] = atof( line.substr( 18 ).c_str() );  // read gain (not dB)
-                        Vgain[i][j] = Transm[i] * atof( line.substr( 20, 33 ).c_str() );  // read gain (not dB)
+                        Vgain[i][j] = /*Transm[i] **/ atof( line.substr( 20, 33 ).c_str() );  // read gain (not dB) //Transm[i] commented for in the antenna gain files "realized gain" is provided and so the transmission coefficient does not need to be multiplied one more time - MLY 01/23/20
                         Vphase[i][j] = atof( line.substr( 34 ).c_str() );  // read gain (not dB)
                                                 
                         //cout<<"VGain : "<<Vgain[i][j]<<", VPhase : "<<Vphase[i][j]<<endl;
@@ -2348,7 +2348,7 @@ inline void Detector::ReadVgain(string filename, Settings *settings1) {
 }// end ReadVgain
 
 
-inline void Detector::ReadVgainTop(string filename, Settings *settings1) {
+inline void Detector::ReadVgainTopSettings(string filename, Settings *settings1) {
     ifstream NecOut( filename.c_str() );
     const int N = freq_step;
 
@@ -2363,14 +2363,14 @@ inline void Detector::ReadVgainTop(string filename, Settings *settings1) {
                     Freq[i] = atof( line.substr(6, line.find_first_of("M")).c_str() );
                     //                    cout<<"freq["<<i<<"] = "<<Freq[i]<<" MHz"<<endl;
                     getline (NecOut, line); //read SWR
-		    Transm[i] = atof( line.substr(5, 11).c_str() );
-		      cerr << "Vpol Transm: " << Transm[i] << endl;
+		              Transm[i] = atof( line.substr(5, 11).c_str() ); //What say "SWR" in "ARA_VPresult_topTrec.txt" is actually transmission coefficient - MYL 01/23/20
+		              //cerr << "Vpol Transm: " << Transm[i] << endl;
 
                     getline (NecOut, line); //read names
 
                     for (int j=0; j<ang_step; j++) {
                         getline (NecOut, line); //read data line
-                        VgainTop[i][j] = Transm[i]*atof( line.substr( 20, 33 ).c_str() );
+                        VgainTop[i][j] = /*Transm[i]**/atof( line.substr( 20, 33 ).c_str() ) ; //Transm[i] commented for in the antenna gain files "realized gain" is provided and so the transmission coefficient does not need to be multiplied one more time - MLY 01/23/20
                         VphaseTop[i][j] = atof( line.substr( 34 ).c_str() );    // + 180.0/TMath::Pi()*TMath::ATan(-Freq[i]/500.0);  // read gain (not dB)
                                                 
                         //cout<<"VGain : "<<Vgain[i][j]<<", VPhase : "<<Vphase[i][j]<<endl;
@@ -2449,7 +2449,7 @@ inline void Detector::ReadHgain(string filename) {
     
 }// end ReadHgain
 
-inline void Detector::ReadHgain(string filename, Settings *settings1) {
+inline void Detector::ReadHgainSettings(string filename, Settings *settings1) {
 
     ifstream NecOut( filename.c_str() );    
     string line;
@@ -2466,14 +2466,14 @@ inline void Detector::ReadHgain(string filename, Settings *settings1) {
                     Freq[i] = atof( line.substr(6, line.find_first_of("M")).c_str() );
                     //                    cout<<"freq["<<i<<"] = "<<Freq[i]<<" MHz"<<endl;
                     getline (NecOut, line); //read SWR
-		    Transm[i] = atof( line.substr(5, 11).c_str() );
+            	     Transm[i] = atof( line.substr(5, 11).c_str() ); //What says "SWR" in "ARA_dipoletest1_output_updated2016.txt" is actually transmission coefficient - MYL 01/23/20 
                     getline (NecOut, line); //read names
                     
                     for (int j=0; j<ang_step; j++) {
                         getline (NecOut, line); //read data line
                         //Hgain[i][j] = atof( line.substr( 20 ).c_str() );  // read gain (not dB)
                         //Hgain[i][j] = atof( line.substr( 18, 25 ).c_str() );  // read gain (not dB)
-                        Hgain[i][j] = Transm[i]*atof( line.substr( 20, 33 ).c_str() );  // read gain (not dB)
+                        Hgain[i][j] = /*Transm[i]**/atof( line.substr( 20, 33 ).c_str() );  // read gain (not dB) //Transm[i] commented for in the antenna gain files "realized gain" is provided and so the transmission coefficient does not need to be multiplied one more time - MLY 01/23/20                      
                         Hphase[i][j] = atof( line.substr( 34 ).c_str() );  // read gain (not dB)
 
                         //cout<<"HGain : "<<Hgain[i][j]<<", HPhase : "<<Hphase[i][j]<<endl;

--- a/Detector.h
+++ b/Detector.h
@@ -217,10 +217,10 @@ class Detector {
         static const int freq_step_max = 60;
         static const int ang_step_max = 2664;
         void ReadVgain(string filename);
-        void ReadVgain(string filename, Settings *settings1);
-	void ReadVgainTop(string filename, Settings *settings1);
+        void ReadVgainSettings(string filename, Settings *settings1);
+	void ReadVgainTopSettings(string filename, Settings *settings1);
         void ReadHgain(string filename);
-	void ReadHgain(string filename, Settings *settings1);
+	void ReadHgainSettings(string filename, Settings *settings1);
         double Vgain[freq_step_max][ang_step_max];
         double Vphase[freq_step_max][ang_step_max];
         double VgainTop[freq_step_max][ang_step_max];

--- a/log.txt
+++ b/log.txt
@@ -1514,3 +1514,7 @@ we even check parameter compatibility. The latter is left as is.
 2020/01/15 Ming-Yuan Lu
 Rename overloaded Settings::CheckCompatibilities functions to Settings::CheckCompatibilitiesSettings() & Settings::CheckCompatibilitiesDetector(Detector *detector) to avoid confusion.
 
+2020/01/23 Ming-Yuan Lu
+1. Renamed ReadVgain(string filename, Settings *settings1), ReadVgainTop(string filename, Settings *settings1), ReadHgain(string filename, Settings *settings1) to ReadVgainSettings(string filename, Settings *settings1), ReadVgainTopSettings(string filename, Settings *settings1), ReadHgainSettings(string filename, Settings *settings1) to prevent confusion over overloaded function names.
+2. For calls to ReadVgainSettings and ReadHgainSettings, pass the correct "..._updated2016.txt" files as arguments to be read. Before, they were reading the wrong hard-coded filenames.
+3. In these 3 functions, stop multiplying the transmission coefficient one more time to the realized gain values as read from the .txt files.


### PR DESCRIPTION
This PR addresses the bug in AraSim ANTENNA_MODE=1, where realistic gain measurements for BV, TV, and H should be applied respectively. 

The bug was two fold:
1. For BV and H, we should read the updated files from 2016 (Chiba measurements). However, this was not done and old files were read.
2. After reading the upated files for BV, TV and H, no additional factor of transmission coefficient should be applied to the gain values since the values are already "realized gain", where the transmission coefficient is already incorporated.

The fix addresses the two bugs above by:
1. Passing the correct updated files to be read
2. Remove the extra factor of transmission coefficient when reading the realized gain
3. Rename read functions to avoid confusion with overloaded function names.

